### PR TITLE
feat: 검색 화면으로 라우팅 기능 구현

### DIFF
--- a/frontend/src/components/Category.jsx
+++ b/frontend/src/components/Category.jsx
@@ -5,6 +5,7 @@ import { AiOutlinePicture } from "react-icons/ai";
 import { SlDrawer } from "react-icons/sl";
 import { BsPersonWorkspace } from "react-icons/bs";
 import "../styles/Category.css";
+import { useNavigate } from "react-router-dom";
 
 const categories = [
   { id: 1, name: "맛집", icon: <IoIosRestaurant />, hashtag: "#맛집" },
@@ -15,10 +16,16 @@ const categories = [
 ];
 
 const Category = () => {
+  const navigate = useNavigate();
+
+  const handleCategoryClick = (hashtag) => {
+    navigate(`/search?query=${encodeURIComponent(hashtag)}`);
+  };
+
   return (
     <div className="category-container">
       {categories.map((category) => (
-        <div key={category.id} className="category-item">
+        <div key={category.id} className="category-item" onClick={() => handleCategoryClick(category.hashtag)}>
           <div className="category-icon">{category.icon}</div>
           <span className="category-name">{category.name}</span>
         </div>

--- a/frontend/src/components/SearchBar.jsx
+++ b/frontend/src/components/SearchBar.jsx
@@ -1,13 +1,17 @@
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { SearchOutlined } from "@ant-design/icons"; // 검색 아이콘
-import "../styles/SearchBar.css";
+import "./SearchBar.css";
 
 const SearchBar = () => {
   const [query, setQuery] = useState("");
+  const navigate = useNavigate();
 
   const handleSearch = (e) => {
     e.preventDefault();
-    console.log("검색어:", query);
+    if (query.trim()) {
+      navigate(`/search?query=${encodeURIComponent(query)}`); // 검색 결과 페이지로 이동
+    }
   };
 
   return (


### PR DESCRIPTION
* 카테고리 선택 -> 각각 #맛집, #카페, #전시회, #소품샵, #연극/공연 해시태그를 쿼리로 넣어 /search로 라우팅
* 검색창 -> 검색명을 쿼리로 넣어 /search로 라우팅