### PR TITLE
feat: 저장 목록 페이지 구현

### DIFF
--- a/frontend/src/pages/SaveListPage.jsx
+++ b/frontend/src/pages/SaveListPage.jsx
@@ -1,0 +1,68 @@
+import Header from "../components/Header";
+import SaveFolder from "../components/SaveFolder";
+import "../styles/SaveListPage.css";
+
+/*가상 데이터*/
+const folders = [
+    {
+        id: 1,
+        folderName: "혼밥 맛집",
+    },
+    {
+        id: 2,
+        imageUrl1: "https://blog.kakaocdn.net/dn/dizeYM/btrN5vZONwk/0ShfJor6t6KANhKzI3Qr1k/img.jpg",
+        folderName: "북카페/ 작업하기 좋은 카페",
+    },
+    {
+        id: 3,
+        folderName: "2025년 1월 전시회",
+    },
+    {
+        id: 4,
+        folderName: "망원동 소품샵",
+    },
+    {
+        id: 5,
+    },
+    {
+        id: 6,
+    },
+    {
+        id: 7,
+    },
+    {
+        id: 8,
+    },
+    {
+        id: 9,
+    },
+    {
+        id: 10,
+    },
+];
+
+
+function SaveListPage() {
+    return (
+        <div className="save-list-page">
+           <Header />
+            <div className="save-title">저장 목록</div>
+                <div className="save-folders">
+                    <div className="save-folder-container">
+                        {folders.map((folder) => (
+                            <SaveFolder
+                                key={folder.id}
+                                imageUrl1={folder.imageUrl1}
+                                imageUrl2={folder.imageUrl2}
+                                imageUrl3={folder.imageUrl3}
+                                imageUrl4={folder.imageUrl4}
+                                folderName={folder.folderName}
+                            />
+                        ))}
+                    </div>
+                </div>
+            </div>
+    );
+};
+
+export default SaveListPage;

--- a/frontend/src/styles/SaveListPage.css
+++ b/frontend/src/styles/SaveListPage.css
@@ -1,0 +1,22 @@
+.save-folders {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 50px;
+}
+.save-title {
+    color: #000000;
+    font-size: 32px;
+    font-family: 'Pretendard';
+    font-weight: 600;
+    text-align: left;
+    margin-left: 250px;
+    margin-top: 50px;
+}
+
+.save-folder-container {
+    display: grid;
+    grid-template-columns: 300px 300px 300px 300px;
+    gap: 80px;
+    border: none;
+}


### PR DESCRIPTION
- 3열로 폴더를 나열하는 경우 페이지 양쪽 여백이 넓어져서 4열로 변경
- 실제로 링크를 연결하여 이미지를 넣어봤더니 border-radius가 적용이 안되어서 폴더 컴포넌트 수정 필요

![image](https://github.com/user-attachments/assets/d72b779e-ef2b-4b75-ae1e-4073189c7969)
